### PR TITLE
fix: update parser to support solidity 0.6.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const fs = require("fs");
 const path = require("path");
 const findUp = require("find-up");
 const tsort = require("tsort");
-const parser = require("solidity-parser-antlr");
+const parser = require("solidity-parser-diligence");
 const mkdirp = require("mkdirp");
 const Resolver = require("@resolver-engine/imports-fs").ImportsFsEngine;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -605,10 +605,10 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "solidity-parser-antlr": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.0.tgz",
-      "integrity": "sha512-RrIsh5VoHmrMQia6yLY8u8rx3JPREhSiCFz4Xb0h1Oh0prUYU2ukyWO8gG892V0UMHIXCWqvdZ3wSctNwdWThg=="
+    "solidity-parser-diligence": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/solidity-parser-diligence/-/solidity-parser-diligence-0.4.18.tgz",
+      "integrity": "sha512-mauO/qG2v59W9sOn5TYV2dS7+fvFKqIHwiku+TH82e1Yca4H8s6EDG12ZpXO2cmgLlCKX3FOqqC73aYLB8WwNg=="
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@resolver-engine/imports-fs": "^0.2.2",
     "find-up": "^2.1.0",
     "mkdirp": "^0.5.1",
-    "solidity-parser-antlr": "^0.4.0",
+    "solidity-parser-diligence": "^0.4.18",
     "tsort": "0.0.1"
   },
   "devDependencies": {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -63,7 +63,7 @@ describe("flattening", function() {
     }
   });
 
-  it("Should leave multiple solidity pragmas", async function() {
+  it("Should filter multiple solidity pragmas", async function() {
     const flattened = await flatten([
       "./contracts/child.sol",
       "./contracts/child.sol",
@@ -71,8 +71,8 @@ describe("flattening", function() {
     ]);
 
     assert.include(flattened, "pragma solidity ^0.5.0;");
-    assert.include(flattened, "pragma solidity >=0.4.24 <0.6.0;");
-    assert.include(flattened, "pragma solidity ^0.5.2;");
+    assert.notInclude(flattened, "pragma solidity >=0.4.24 <0.6.0;");
+    assert.notInclude(flattened, "pragma solidity ^0.5.2;");
   });
 
   it("Should fail if the provided root directory does not exist", async function() {


### PR DESCRIPTION
This PR includes the commit from @KaiRo-at in https://github.com/nomiclabs/truffle-flattener/pull/49, which was exactly what we needed.

It also fixes some tests that were not passing with the last commit :smile: 